### PR TITLE
[1/2]: Note the potential confusion with merged PRs as shortcoming

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -85,7 +85,7 @@ impl Change {
             }
             body.push('\n');
         }
-        body.push_str(&format!("- `{}`\n\n<sub>(Note: Closed and merged PRs are not reflected here and PR numbering is not stable.)</sub>\n", env::base_branch()));
+        body.push_str(&format!("- `{}`\n\n<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>\n", env::base_branch()));
         let count = changes.len();
         let position = count
             - index.expect(

--- a/src/env.rs
+++ b/src/env.rs
@@ -87,6 +87,9 @@ fn read_config() -> Result<Config> {
 ///   stale with no relation to the latest patch contents. This seems to happen frequently anyway,
 ///   and avoiding it in the general case requires never rebasing which is not viable for anything
 ///   but an extremely short-lived review process.
+/// * Loses track of merged/closed PRs. This may be mildly confusing, but is more-or-less by
+///   design: the change commit which corresponds to a merged PR will naturally disappear from the
+///   branch on rebase.
 /// * Currently lacks a lot of polish and documentation.
 ///
 /// It reads configuration from the first of the following:


### PR DESCRIPTION
Change-Id: I69a7993007c901a8a0f4c9a8bda9eb8058b7f880

---

**Stack**:
- #7
- #8⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
