### PR TITLE
[1/4]: Clarify what gd "never touches" in the local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See `--help` for more.
 
 The most compelling alternative to `gd` is https://github.com/ejoffe/spr which differs in a few ways:
 
-* `spr` will modify your local repo by default for logically non-destructive operations (i.e. when you try to `update` the remote)
+* `spr` will modify your local branches by default for logically non-destructive operations (i.e. when you try to `update` the remote)
 * `spr` won't use Gerrit `Change-Id:`, and is very particular about the format of its ID; `gd` allows any string and uses the `Change-Id:` trailer
 * `spr` does not seem to have a `dry-run` option, so modifications aren't forseeable
 * `spr` installs itself as a git subcommand (this is really just an aesthetic quibble, but I don't think it is primarily a `git` tool, it is a GitHub tool, and exists only to patch a deficiency in GitHub as a service)

--- a/src/env.rs
+++ b/src/env.rs
@@ -66,8 +66,9 @@ fn read_config() -> Result<Config> {
 ///
 /// Main features:
 ///
-/// * Never touches your local repo. The tool only reads from your local repo and attempts to
-///   mirror it to GitHub by pushing refs, create PRs, and "stacking" them.
+/// * Never touches your local branches. The tool only reads from your local branch and attempts to
+///   mirror it to GitHub by: fetching remote tracking branches, force-pushing namespaced refs,
+///   creating PRs, and maintaining PR bodies and comments to present a pseudo-UI for the stack.
 /// * Treats one branch as one patch-stack, where each commit maps 1:1 to a PR.
 /// * Uses the same "Change-Id" trailer used by Gerrit. You can install the commit-msg hook from
 ///   a Gerrit instance or use the install-hook subcommand to install an embedded copy.


### PR DESCRIPTION
The original wording is too strong, the actual feature is that the tool
does not modify local branches.

Change-Id: I9cddb19f9185245cdf0960ecd83d694055d2f57c

---

**Stack**:
- #7
- #8
- #9
- #10⬅
- `main`

<sub>(Note: Closed and merged PRs are not reflected here and PR numbering is not stable.)</sub>
