### PR TITLE
[1/1]: Fix a bug where we accidentally --force pushed all refs

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -46,17 +46,25 @@ impl LocalChange {
         format!("{oid}:{remote_branch_ref}")
     }
     pub fn push_all<'a, I: Iterator<Item = &'a Self>>(iterator: I) -> Result<()> {
+        let refspecs: Vec<String> = iterator.map(|lc| lc.push_refspec()).collect();
+        if refspecs.is_empty() {
+            bail!("no refs to push");
+        }
         let mut cmd = Command::new("git");
         let mut args = vec!["push".to_string(), env::remote().into(), "--force".into()];
-        args.extend(iterator.map(|lc| lc.push_refspec()));
+        args.extend(refspecs);
         cmd.args(args);
         exec!(dry_return = (), cmd);
         Ok(())
     }
     pub fn fetch_all<'a, I: Iterator<Item = &'a Self>>(iterator: I) -> Result<()> {
+        let refspecs: Vec<String> = iterator.map(|lc| lc.push_refspec()).collect();
+        if refspecs.is_empty() {
+            bail!("no refs to fetch");
+        }
         let mut cmd = Command::new("git");
         let mut args = vec!["fetch".to_string(), env::remote().into()];
-        args.extend(iterator.map(|lc| lc.remote_branch()));
+        args.extend(refspecs);
         cmd.args(args);
         exec!(dry_return = (), cmd);
         Ok(())


### PR DESCRIPTION
Change-Id: I9a5ce054e0ee0ec43390f3486d2bb2e69c9ba8ae

---

**Stack**:
- #14⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
