### PR TITLE
[1/1]: Handle long PR/comment bodies more cleanly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +268,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "tlrepo",
  "toml",
 ]
@@ -448,9 +465,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libgit2-sys"
@@ -503,6 +520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +542,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -633,6 +662,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +770,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,6 @@ lazy_static = "1.5.0"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
+tempfile = "3.27.0"
 tlrepo = "0.8.0"
 toml = "1.0.2"

--- a/src/gd.rs
+++ b/src/gd.rs
@@ -157,7 +157,10 @@ fn push(cfg: &cli::Push) -> Result<()> {
         .filter(|(c, _)| c.is_nonempty())
         .map(|(c, diff)| {
             if !diff.is_empty() {
-                c.pr.add_comment(format!("Changes since last push:\n```diff\n{diff}\n```"))
+                c.pr.add_details_comment(
+                    "Changes since last push (click to expand):".to_string(),
+                    format!("```diff\n{diff}\n```"),
+                )
             } else {
                 Ok(())
             }

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -9,7 +9,9 @@ use git2::message_trailers_strs;
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::io::Write;
 use std::process::Command;
+use tempfile::NamedTempFile;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +34,41 @@ pub enum PrState {
 
 fn gh() -> Command {
     Command::new("gh")
+}
+
+/// A guess at a reasonable size for one arg to avoid making the command-line
+/// too long. Anything longer than this will use a tempfile.
+const MAX_INLINE_ARG_LENGTH: usize = 0x1000;
+
+struct ArgInlineOrFile {
+    arg_base: &'static str,
+    file: Option<NamedTempFile>,
+}
+impl ArgInlineOrFile {
+    pub fn new(arg_base: &'static str) -> ArgInlineOrFile {
+        ArgInlineOrFile {
+            arg_base,
+            file: None,
+        }
+    }
+    pub fn arg<S: AsRef<str>>(&mut self, contents: S) -> Result<String> {
+        let ret: String;
+        let arg_base = self.arg_base;
+        let contents = contents.as_ref();
+        let contents_bytes = contents.as_bytes();
+        if contents_bytes.len() > MAX_INLINE_ARG_LENGTH {
+            let mut file = NamedTempFile::new()?;
+            file.write_all(contents_bytes)?;
+            let path = file.path().to_str().context("arg file path is not utf-8")?;
+            ret = format!("--{arg_base}-file={path}");
+            if self.file.replace(file).is_some() {
+                bail!("ArgInlineOrFile was reused");
+            }
+        } else {
+            ret = format!("--{arg_base}={contents}");
+        }
+        Ok(ret)
+    }
 }
 
 lazy_static! {
@@ -78,11 +115,9 @@ impl Pr {
     }
 
     pub fn set_title_and_body(&self, title: &str, body: &str) -> Result<()> {
+        let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
-        let args = self.args_for(
-            "edit",
-            [format!("--title={title}"), format!("--body={body}")],
-        );
+        let args = self.args_for("edit", [format!("--title={title}"), body_arg.arg(body)?]);
         cmd.args(args);
         exec!(dry_return = (), cmd);
         Ok(())
@@ -109,9 +144,11 @@ impl Pr {
         Ok(())
     }
 
-    pub fn add_comment(&self, comment: String) -> Result<()> {
+    pub fn add_details_comment(&self, summary: String, body: String) -> Result<()> {
+        let comment = format!("<details>\n<summary>{summary}</summary>\n\n{body}\n</details>");
+        let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
-        let args = self.args_for("comment", [format!("--body={}", comment)]);
+        let args = self.args_for("comment", [body_arg.arg(comment)?]);
         cmd.args(args);
         exec!(dry_return = (), cmd);
         Ok(())
@@ -136,6 +173,7 @@ impl Pr {
         let title = commit.summary().context("commit has no summary")?;
         let body = commit.body().context("commit has no body")?;
         let base = env::base_branch();
+        let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
         let args = vec![
             "pr".into(),
@@ -144,7 +182,7 @@ impl Pr {
             "--draft".into(),
             format!("--base={base}"),
             format!("--title={title}"),
-            format!("--body={body}"),
+            body_arg.arg(body)?,
             format!("--head={remote_branch_ref}"),
         ];
         cmd.args(args);


### PR DESCRIPTION
Use temporary arg files if we might even start to approach the command-line
length limit.

Collapse interdiff comments. We could add the "open" attribute for
comments which aren't too long, but where to make the cutoff isn't
clear, and it seems confusing for the reviewer to sometimes have to
expand and sometimes not.

Change-Id: Iedf4cdf8e076fec9daaf6b1261181a4296c737dd

---

**Stack**:
- #34⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
