### PR TITLE
[1/1]: Also generate diff for initial change

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -6,7 +6,8 @@ use crate::gh::Pr;
 use crate::util::exec;
 use anyhow::{Context, Result, bail};
 use git2::{
-    Commit, DiffFormat, DiffOptions, FileFavor, MergeOptions, Oid, Tree, message_trailers_bytes,
+    Commit, DiffDelta, DiffFormat, DiffHunk, DiffLine, DiffOptions, FileFavor, MergeOptions, Oid,
+    Tree, message_trailers_bytes,
 };
 use std::process::Command;
 
@@ -23,6 +24,41 @@ impl AnyChange {
             AnyChange::Change(change) => &change.local_change,
         }
     }
+    pub fn diff(&self) -> Result<Diff> {
+        Ok(match self {
+            AnyChange::LocalChange(local_change) => Diff::InitialDiff(local_change.diff()?),
+            AnyChange::Change(change) => Diff::InterDiff(change.interdiff()?),
+        })
+    }
+}
+
+pub enum Diff {
+    InitialDiff(String),
+    InterDiff(String),
+}
+
+type DiffPrinter<'a> = Box<dyn FnMut(DiffDelta, Option<DiffHunk>, DiffLine) -> bool + 'a>;
+
+fn diff_printer<'a>(out: &'a mut String) -> DiffPrinter<'a> {
+    Box::new(|_delta, _hunk, line| {
+        match line.origin() {
+            '+' | '-' | ' ' => out.push(line.origin()),
+            _ => {}
+        }
+        let s = str::from_utf8(line.content()).expect("non-utf8 encoded content in diff");
+        // The file mode and index info is just noise here, but I don't see how to disable both
+        // in the options. Just rely on the output of the 'F' origin "line" and strip
+        // everything but the `diff --git <A> <B>` part.
+        if line.origin() == 'F'
+            && let Some((p, _)) = s.split_once('\n')
+        {
+            out.push_str(p);
+            out.push('\n')
+        } else {
+            out.push_str(s)
+        };
+        true
+    })
 }
 
 #[derive(Debug)]
@@ -79,6 +115,27 @@ impl LocalChange {
     }
     pub fn is_nonempty(&self) -> bool {
         !self.is_empty().unwrap_or(false)
+    }
+    pub fn diff(&self) -> Result<String> {
+        let change = self.id.as_str();
+        let repo = env::repo();
+        let commit = repo
+            .find_commit(self.oid)
+            .expect("a local change's commit Oid is not found in the repo now?");
+        let parent = commit
+            .parent(0)
+            .with_context(|| format!("change {change} has no parent commit",))?;
+        let mut diff_opts = DiffOptions::new();
+        diff_opts.reverse(true);
+        let diff = repo.diff_tree_to_tree(
+            Some(&tree(&commit)?),
+            Some(&tree(&parent)?),
+            Some(&mut diff_opts),
+        )?;
+        let mut out = String::new();
+        diff.print(DiffFormat::Patch, diff_printer(&mut out))
+            .with_context(|| format!("failed to generate interdiff for change {change}"))?;
+        Ok(out)
     }
 }
 
@@ -158,26 +215,8 @@ impl Change {
             Some(&mut diff_opts),
         )?;
         let mut out = String::new();
-        diff.print(DiffFormat::Patch, |_delta, _hunk, line| {
-            match line.origin() {
-                '+' | '-' | ' ' => out.push(line.origin()),
-                _ => {}
-            }
-            let s = str::from_utf8(line.content()).expect("non-utf8 encoded content in diff");
-            // The file mode and index info is just noise here, but I don't see how to disable both
-            // in the options. Just rely on the output of the 'F' origin "line" and strip
-            // everything but the `diff --git <A> <B>` part.
-            if line.origin() == 'F'
-                && let Some((p, _)) = s.split_once('\n')
-            {
-                out.push_str(p);
-                out.push('\n')
-            } else {
-                out.push_str(s)
-            };
-            true
-        })
-        .with_context(|| format!("failed to generate interdiff for change {change}"))?;
+        diff.print(DiffFormat::Patch, diff_printer(&mut out))
+            .with_context(|| format!("failed to generate interdiff for change {change}"))?;
         Ok(out)
     }
     pub fn is_nonempty(&self) -> bool {

--- a/src/gd.rs
+++ b/src/gd.rs
@@ -1,7 +1,7 @@
 // Copyright © 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-use crate::change::{self, AnyChange, Change, LocalChange};
+use crate::change::{self, AnyChange, Change, Diff, LocalChange};
 use crate::cli;
 use crate::env;
 use crate::gh::{self, Pr, PrState};
@@ -97,14 +97,11 @@ fn push(cfg: &cli::Push) -> Result<()> {
         _ => None,
     }))
     .context("could not fetch base branches for all existing prs")?;
-    let interdiffs = any_changes
+    let diffs = any_changes
         .par_iter()
-        .map(|ac| match ac {
-            AnyChange::Change(c) => c.interdiff(),
-            _ => Ok("".into()),
-        })
+        .map(|ac| ac.diff())
         .collect::<Result<Vec<_>>>()
-        .context("could not build interdiffs")?;
+        .context("could not build diffs")?;
     // FIXME: Should we push a slightly modified version of the branch with empty commits stripped
     // out? It would clean up the "Commits" tab on the PRs, and make the final merge message
     // correct without edits.
@@ -153,17 +150,13 @@ fn push(cfg: &cli::Push) -> Result<()> {
         .context("could not set pr bases and bodies")?;
     changes
         .par_iter()
-        .zip(interdiffs)
-        .filter(|(c, _)| c.is_nonempty())
+        .zip(diffs)
         .map(|(c, diff)| {
-            if !diff.is_empty() {
-                c.pr.add_details_comment(
-                    "Changes since last push (click to expand):".to_string(),
-                    format!("```diff\n{diff}\n```"),
-                )
-            } else {
-                Ok(())
-            }
+            let (summary, body) = match diff {
+                Diff::InitialDiff(text) => ("Initial changes", text),
+                Diff::InterDiff(text) => ("Changes since last push", text),
+            };
+            c.pr.add_details_comment(summary.to_string(), format!("```diff\n{body}\n```"))
         })
         .collect::<Result<Vec<_>>>()
         .context("could not add interdiff comments")?;

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -145,7 +145,9 @@ impl Pr {
     }
 
     pub fn add_details_comment(&self, summary: String, body: String) -> Result<()> {
-        let comment = format!("<details>\n<summary>{summary}</summary>\n\n{body}\n</details>");
+        let comment = format!(
+            "<details>\n<summary>🛠️ {summary} (click to expand):</summary>\n\n{body}\n</details>"
+        );
         let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
         let args = self.args_for("comment", [body_arg.arg(comment)?]);


### PR DESCRIPTION
Add an emoji to draw a little more attention to the collapsed comment,
and differentiate it a bit more from user comments.

Change-Id: I14122a25e107e1a6c25e225b225db7834ef0f395

---

**Stack**:
- #37⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
