### PR TITLE
[1/1]: Add --atomic for pushes

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -87,7 +87,12 @@ impl LocalChange {
             bail!("no refs to push");
         }
         let mut cmd = Command::new("git");
-        let mut args = vec!["push".to_string(), env::remote().into(), "--force".into()];
+        let mut args = vec![
+            "push".to_string(),
+            env::remote().into(),
+            "--force".into(),
+            "--atomic".into(),
+        ];
         args.extend(refspecs);
         cmd.args(args);
         exec!(dry_return = (), cmd);


### PR DESCRIPTION
We still don't restore changes if we fail after the push, but we will
at least not partially update refs if we fail during the push.

Change-Id: I1a91a08dbecb7738d63e836cb43fe9e2c627e560

---

**Stack**:
- #38⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
