### PR TITLE
[1/1]: Improve push comment when diff is empty

### DIFF
--- a/src/gd.rs
+++ b/src/gd.rs
@@ -1,7 +1,7 @@
 // Copyright © 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-use crate::change::{self, AnyChange, Change, Diff, LocalChange};
+use crate::change::{self, AnyChange, Change, LocalChange};
 use crate::cli;
 use crate::env;
 use crate::gh::{self, Pr, PrState};
@@ -151,13 +151,7 @@ fn push(cfg: &cli::Push) -> Result<()> {
     changes
         .par_iter()
         .zip(diffs)
-        .map(|(c, diff)| {
-            let (summary, body) = match diff {
-                Diff::InitialDiff(text) => ("Initial changes", text),
-                Diff::InterDiff(text) => ("Changes since last push", text),
-            };
-            c.pr.add_details_comment(summary.to_string(), format!("```diff\n{body}\n```"))
-        })
+        .map(|(c, diff)| c.pr.add_details_comment(&diff))
         .collect::<Result<Vec<_>>>()
         .context("could not add interdiff comments")?;
     changes

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,7 +1,7 @@
 // Copyright © 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: MIT
 
-use crate::change::LocalChange;
+use crate::change::{Diff, LocalChange};
 use crate::env;
 use crate::util::{Extract, exec};
 use anyhow::{Context, Result, bail};
@@ -144,10 +144,18 @@ impl Pr {
         Ok(())
     }
 
-    pub fn add_details_comment(&self, summary: String, body: String) -> Result<()> {
-        let comment = format!(
-            "<details>\n<summary>🛠️ {summary} (click to expand):</summary>\n\n{body}\n</details>"
-        );
+    pub fn add_details_comment(&self, diff: &Diff) -> Result<()> {
+        let (summary, changes) = match diff {
+            Diff::InitialDiff(text) => ("Initial changes", text),
+            Diff::InterDiff(text) => ("Changes since last push", text),
+        };
+        let comment = if changes.is_empty() {
+            format!("🛠️ {summary}: none (likely a rebase)")
+        } else {
+            format!(
+                "<details>\n<summary>🛠️ {summary} (click to expand):</summary>\n\n```diff\n{changes}\n```\n</details>"
+            )
+        };
         let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
         let args = self.args_for("comment", [body_arg.arg(comment)?]);


### PR DESCRIPTION
Change-Id: I1125aa8a0ac19d682ddc1db1f2e5a837f1a35a4f

---

**Stack**:
- #40⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
