### PR TITLE
[1/1]: Stop spamming everyone with empty messages

### DIFF
--- a/src/cgh.rs
+++ b/src/cgh.rs
@@ -152,6 +152,7 @@ fn push(cfg: &cli::Push) -> Result<()> {
     changes
         .par_iter()
         .zip(diffs)
+        .filter(|(c, _)| c.is_nonempty())
         .map(|(c, diff)| c.pr.add_details_comment(&diff))
         .collect::<Result<Vec<_>>>()
         .context("could not add interdiff comments")?;

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -150,15 +150,14 @@ impl Pr {
     pub fn add_details_comment(&self, diff: &Diff) -> Result<()> {
         let (summary, changes) = match diff {
             Diff::InitialDiff(text) => ("Initial changes", text),
-            Diff::InterDiff(text) => ("Changes since last push", text),
+            Diff::InterDiff(text) => ("Changes since last version", text),
         };
-        let comment = if changes.is_empty() {
-            format!("🛠️ {summary}: none (likely a rebase)")
-        } else {
-            format!(
-                "<details>\n<summary>🛠️ {summary} (click to expand):</summary>\n\n```diff\n{changes}\n```\n</details>"
-            )
-        };
+        if changes.is_empty() {
+            return Ok(());
+        }
+        let comment = format!(
+            "<details>\n<summary>🛠️ {summary} (click to expand):</summary>\n\n```diff\n{changes}\n```\n</details>"
+        );
         let mut body_arg = ArgInlineOrFile::new("body");
         let mut cmd = gh();
         let args = self.args_for("comment", [body_arg.arg(comment)?]);


### PR DESCRIPTION
The idea with the "Changes since last push: none" comments was to make
it clear that a force-push was just incidental to the stacking hack. In
practice a couple of rebases or changes in other commits in the stack
could lead to the comment being repeated several times in a short
period, which is understandably annoying.

I still think comments for *actual interdiffs* are useful enough to
retain.

Change-Id: I00742310e87ee0d7ca9aa2174213cccff6b0ece2

---

**Stack**:
- #54⬅
- `main`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
